### PR TITLE
[BUGFIX] Fix composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
 		"typo3/cms-core": "*"
 	},
 	"replace": {
-		"cookie-consent": "self.version",
+		"cookie_consent": "self.version",
 		"typo3-ter/cookie-consent": "self.version"
 	},
 	"autoload": {


### PR DESCRIPTION
Composer installs the extension into typo3conf/ext/cookie-consent at the moment. This fixes the problem.